### PR TITLE
better apply macro

### DIFF
--- a/examples/factorial.asm
+++ b/examples/factorial.asm
@@ -1,0 +1,25 @@
+global _start
+extern printf
+section .text
+factorial:
+mov rsi, 2
+mov rax, 1
+startwhile0:
+cmp rsi, rdi
+jg endwhile0
+mul rsi
+inc rsi
+jmp startwhile0
+endwhile0:
+ret
+_start:
+mov rdi, 3
+call factorial
+mov rdi, fmt
+mov rsi, rax
+call printf
+mov rax, 60
+syscall
+ret
+section .data
+fmt: db "%d", 10, 0

--- a/examples/strchr.asm
+++ b/examples/strchr.asm
@@ -1,0 +1,33 @@
+global _start
+extern printf
+section .text
+strchr:
+mov rax, 0
+startwhile0:
+cmp byte[rdi], 0
+je endwhile0
+cmp byte[rdi], sil
+jne endif0
+mov rax, rdi
+ret
+endif0:
+inc rdi
+jmp startwhile0
+endwhile0:
+ret
+_start:
+mov rdi, teststr
+mov rsi, 87
+call strchr
+mov rdi, fmt
+mov rsi, rax
+call printf
+mov rdi, fmt
+mov rsi, teststr
+call printf
+mov rax, 60
+syscall
+ret
+section .data
+teststr: db "Hello World!", 0
+fmt: db "%p", 10, 0

--- a/examples/strchr.con
+++ b/examples/strchr.con
@@ -4,23 +4,25 @@ section .text
 function strchr(str, chr):
 	!ptrresult rax
 	!findchr sil
-	mov ptrresult, 0
-	while byte[str] ne 0:
+	!end_of_str 0
+	!nullptr 0
+	mov ptrresult, nullptr
+	while byte[str] ne end_of_str:
 		if byte[str] e findchr:
 			mov ptrresult, str
 			ret
 		inc str
 
 function main():
-	call strchr(teststr, 87)
+	!W_letter 87
+	call strchr(teststr, W_letter)
 	!result rax
 	call printf(fmt, result)
 	call printf(fmt, teststr)
 
-	mov rax, 60
-	syscall
+	syscall exit()
 
 section .data
-fmt: db "%p", 10, 0
 teststr: db "Hello World!", 0
+fmt: db "%p", 10, 0
 

--- a/examples/strlwr.asm
+++ b/examples/strlwr.asm
@@ -1,0 +1,32 @@
+global _start
+extern printf
+section .text
+strlwr:
+startwhile0:
+cmp byte[rdi], 0
+je endwhile0
+cmp byte[rdi], 65
+jl endif1
+cmp byte[rdi], 90
+jg endif0
+mov sil, byte[rdi]
+add sil, 32
+mov byte[rdi], sil
+endif0:
+endif1:
+inc rdi
+jmp startwhile0
+endwhile0:
+ret
+_start:
+mov rdi, teststr
+call strlwr
+mov rdi, fmt
+mov rsi, teststr
+call printf
+mov rax, 60
+syscall
+ret
+section .data
+teststr: db "HeLlO WoRlD", 0
+fmt: db "%s", 10, 0

--- a/examples/strlwr.con
+++ b/examples/strlwr.con
@@ -2,24 +2,27 @@ extern printf
 
 section .text
 function strlwr(str):
-	while byte[str] ne 0:
-		if byte[str] ge 65:
-			if byte[str] le 90:
+	!A_letter 65
+	!Z_letter 90
+	!end_of_str 0
+	!A_to_a 32
+	while byte[str] ne end_of_str:
+		if byte[str] ge A_letter:
+			if byte[str] le Z_letter:
 				!crntchr sil
 				mov crntchr, byte[str]
-				add crntchr, 32
+				add crntchr, A_to_a
 				mov byte[str], crntchr
 		inc str
 
 
 function main():
-	call strlwr(teststring)
-	call printf(fmt, teststring)
+	call strlwr(teststr)
+	call printf(fmt, teststr)
 
-	mov rax, 60
-	syscall
+	syscall exit()
 
 section .data
-teststring db "HeLlO WoRlD", 0
+teststr: db "HeLlO WoRlD", 0
 fmt: db "%s", 10, 0
 

--- a/src/construct.cpp
+++ b/src/construct.cpp
@@ -41,12 +41,22 @@ int main(int argc, char** argv)
   apply_whiles(tokens);
   apply_funcalls(tokens);
   apply_syscalls(tokens);
-  std::vector<con_macro> empty_macros;
+  std::vector<con_macro*> empty_macros; // pointer to con_macros in tokens, not a copy
   apply_macros(tokens, empty_macros);
+  empty_macros.clear(); // remove the pointers to con_macro, not the con_macro objects themselves
   linearize_tokens(tokens);
 
   std::ofstream outfile;
   outfile.open(outpath);
   outfile << tokens_to_nasm(tokens);
   outfile.close();
+
+  for (std::vector<con_token*>::reverse_iterator r_it = tokens.rbegin(); r_it != tokens.rend(); ++r_it) {
+    delete *r_it;
+    *r_it = nullptr;
+  }
+  tokens.clear();
+  glob_cmd = nullptr; // deleted in tokens vector
+  glob_tok = nullptr; // deleted in tokens vector
+  return 0;
 }

--- a/src/construct_debug.cpp
+++ b/src/construct_debug.cpp
@@ -17,7 +17,7 @@ std::string tokentype_to_string(CON_TOKENTYPE type)
     case IF:
       return "if";
     case FUNCTION:
-      return "func";
+      return "function";
     case CMD:
       return "cmd";
     case MACRO:

--- a/src/construct_types.h
+++ b/src/construct_types.h
@@ -32,27 +32,12 @@ enum CON_TOKENTYPE {
   SYSCALL
 };
 
-
-struct con_token {
-  CON_TOKENTYPE tok_type;
-  int indentation;
-  struct con_section* tok_section;
-  struct con_tag* tok_tag;
-  struct con_while* tok_while;
-  struct con_if* tok_if;
-  struct con_function* tok_function;
-  struct con_cmd* tok_cmd;
-  struct con_macro* tok_macro;
-  struct con_funcall* tok_funcall;
-  struct con_syscall* tok_syscall;
-  std::vector<con_token*> tokens; // relevant to "if", "while", "function" and "syscall" tokens
-};
-
 struct _con_condition {
   CON_COMPARISON op;
   std::string arg1;
   std::string arg2;
 };
+
 
 struct con_section {
   std::string name;
@@ -94,6 +79,54 @@ struct con_funcall {
 struct con_syscall {
   uint16_t number;
   std::vector<std::string> arguments;
+};
+
+
+struct con_token {
+  CON_TOKENTYPE tok_type;
+  int indentation;
+  con_section* tok_section = nullptr;
+  con_tag* tok_tag = nullptr;
+  con_while* tok_while = nullptr;
+  con_if* tok_if = nullptr;
+  con_function* tok_function = nullptr;
+  con_cmd* tok_cmd = nullptr;
+  con_macro* tok_macro = nullptr;
+  con_funcall* tok_funcall = nullptr;
+  con_syscall* tok_syscall = nullptr;
+  std::vector<con_token*> tokens; // relevant to "if", "while", "function" and "syscall" tokens
+
+  ~con_token() {
+    switch (tok_type) {
+      case SECTION:
+        if (tok_section != nullptr) delete tok_section;
+      break;
+      case TAG:
+        if (tok_tag != nullptr) delete tok_tag;
+      break;
+      case WHILE:
+        if (tok_while != nullptr) delete tok_while;
+      break;
+      case IF:
+        if (tok_if != nullptr) delete tok_if;
+      break;
+      case FUNCTION:
+        if (tok_function != nullptr) delete tok_function;
+      break;
+      case CMD:
+        if (tok_cmd != nullptr) delete tok_cmd;
+      break;
+      case MACRO:
+        if (tok_macro != nullptr) delete tok_macro;
+      break;
+      case FUNCALL:
+        if (tok_funcall != nullptr) delete tok_funcall;
+      break;
+      case SYSCALL:
+        if (tok_syscall != nullptr) delete tok_syscall;
+      break;
+    }
+  }
 };
 
 #endif // CONSTRUCT_TYPES_H_

--- a/src/deconstruct.cpp
+++ b/src/deconstruct.cpp
@@ -8,7 +8,6 @@
 
 using namespace std;
 
-static void to_lower(string& str);
 static vector<string> split(const string& input, const string& chars);
 static uint16_t get_syscall_number(const std::string& syscall_name);
 
@@ -71,10 +70,9 @@ vector<con_token*> delinearize_tokens(std::vector<con_token*> tokens)
   vector<con_token*> dl_tokens;
 
   // Serves as parent "section" where all tokens belong to, convenient for algo
-  con_section* parent_section = new con_section;
   con_token* parent_token = new con_token;
-  parent_token->tok_section = parent_section;
   parent_token->tok_type = SECTION;
+  parent_token->tok_section = new con_section; // is deleted inside parent_token
   parent_token->indentation = -1;
 
   stack<con_token*> parent_stack;
@@ -105,8 +103,8 @@ vector<con_token*> delinearize_tokens(std::vector<con_token*> tokens)
 
   vector<con_token*> delinearized_tokens = parent_token->tokens;
 
-  delete parent_section;
   delete parent_token;
+  parent_token = nullptr;
 
   return delinearized_tokens;
 }
@@ -244,7 +242,6 @@ con_token* parse_line(string line)
 }
 vector<con_token*> parse_construct(string code)
 {
-  to_lower(code);
   vector<string> code_split = split(code, "\n");
   vector<con_token*> tokens;
   bool in_data = false;
@@ -279,16 +276,6 @@ vector<con_token*> parse_construct(string code)
 }
 
 // ----- ----- ----- ----- ----- ----- helper functions impl ----- ----- ----- ----- -----
-
-void to_lower(string& str)
-{
-  for (string::iterator it = str.begin(); it != str.end(); ++it) {
-    if (*it >= 'A' && *it <= 'Z') {
-      *it -= 'A';
-      *it += 'a';
-    }
-  }
-}
 
 vector<string> split(const string& input, const string& chars)
 {

--- a/src/reconstruct.h
+++ b/src/reconstruct.h
@@ -20,7 +20,7 @@ CON_COMPARISON get_comparison_inverse(CON_COMPARISON condition);
 void apply_whiles(std::vector<con_token*>& tokens);
 void apply_ifs(std::vector<con_token*>& tokens);
 void apply_functions(std::vector<con_token*>& tokens);
-void apply_macros(std::vector<con_token*>& tokens, std::vector<con_macro> macros);
+void apply_macros(std::vector<con_token*>& tokens, std::vector<con_macro*>& macros);
 void apply_funcalls(std::vector<con_token*>& tokens);
 void apply_syscalls(std::vector<con_token*>& tokens);
 


### PR DESCRIPTION
src/construct_types.h: added "con_token" destructor
src/construct.cpp: free allocated memory
src/deconstruct.cpp: remove to_lower() function and usage
src/reconstruct.cpp: same apply-macro logic but better code. also fixed issue of using "_" as a split between words.
examples/*.con: using macros for magic numbers
examples/*.asm: showing the results of the example inputs