### PR TITLE
assert_throw, arg len, make test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+out/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,50 @@
-CC = g++
-CFLAGS = -std=c++11 -Wall --pedantic-errors -g
+CXX = g++
+CXXFLAGS = -std=c++11 -Wall --pedantic-errors -g
 SDIR = src
+EDIR = examples
 BDIR = bin
+ODIR = out
 _OBJS = construct_debug.o construct_flags.o deconstruct.o reconstruct.o construct.o
 OBJS =  $(patsubst %,$(BDIR)/%,$(_OBJS))
 PROG = construct.exe
 
-.PHONY: all clean
+.PHONY: all clean test
 
 all: $(OBJS) $(BDIR)/$(PROG)
 
 $(BDIR)/$(PROG): $(OBJS)
 	mkdir -p $(BDIR)
-	$(CC) $(OBJS) -o $(BDIR)/$(PROG) $(CFLAGS)
+	$(CXX) $(OBJS) -o $(BDIR)/$(PROG) $(CXXFLAGS)
 
 $(BDIR)/construct.o: $(SDIR)/construct.cpp $(SDIR)/deconstruct.h $(SDIR)/reconstruct.h $(SDIR)/construct_flags.h $(SDIR)/construct_types.h
 	mkdir -p $(BDIR)
-	$(CC) -c $(SDIR)/construct.cpp -o $(BDIR)/construct.o $(CFLAGS)
+	$(CXX) -c $(SDIR)/construct.cpp -o $(BDIR)/construct.o $(CXXFLAGS)
 
 $(BDIR)/construct_debug.o: $(SDIR)/construct_debug.cpp $(SDIR)/construct_debug.h $(SDIR)/construct_types.h $(SDIR)/reconstruct.h
 	mkdir -p $(BDIR)
-	$(CC) -c $(SDIR)/construct_debug.cpp -o $(BDIR)/construct_debug.o $(CFLAGS)
+	$(CXX) -c $(SDIR)/construct_debug.cpp -o $(BDIR)/construct_debug.o $(CXXFLAGS)
 
 $(BDIR)/construct_flags.o: $(SDIR)/construct_flags.cpp $(SDIR)/construct_flags.h $(SDIR)/construct_types.h
 	mkdir -p $(BDIR)
-	$(CC) -c $(SDIR)/construct_flags.cpp -o $(BDIR)/construct_flags.o $(CFLAGS)
+	$(CXX) -c $(SDIR)/construct_flags.cpp -o $(BDIR)/construct_flags.o $(CXXFLAGS)
 
 $(BDIR)/deconstruct.o: $(SDIR)/deconstruct.cpp $(SDIR)/deconstruct.h $(SDIR)/construct_types.h
 	mkdir -p $(BDIR)
-	$(CC) -c $(SDIR)/deconstruct.cpp -o $(BDIR)/deconstruct.o $(CFLAGS)
+	$(CXX) -c $(SDIR)/deconstruct.cpp -o $(BDIR)/deconstruct.o $(CXXFLAGS)
 
 $(BDIR)/reconstruct.o: $(SDIR)/reconstruct.cpp $(SDIR)/reconstruct.h $(SDIR)/construct_types.h
 	mkdir -p $(BDIR)
-	$(CC) -c $(SDIR)/reconstruct.cpp -o $(BDIR)/reconstruct.o $(CFLAGS)
+	$(CXX) -c $(SDIR)/reconstruct.cpp -o $(BDIR)/reconstruct.o $(CXXFLAGS)
 
 clean:
-	rm -rf $(BDIR)
+	rm -rf $(BDIR) $(ODIR)
+
+test: $(BDIR)/$(PROG)
+	rm -rf $(ODIR)
+	mkdir -p $(ODIR)
+	$(BDIR)/$(PROG) -f elf64 -i $(EDIR)/factorial.con -o $(ODIR)/factorial.asm
+	diff --strip-trailing-cr $(EDIR)/factorial.asm $(ODIR)/factorial.asm
+	$(BDIR)/$(PROG) -f elf64 -i $(EDIR)/strchr.con    -o $(ODIR)/strchr.asm
+	diff --strip-trailing-cr $(EDIR)/strchr.asm    $(ODIR)/strchr.asm
+	$(BDIR)/$(PROG) -f elf64 -i $(EDIR)/strlwr.con    -o $(ODIR)/strlwr.asm
+	diff --strip-trailing-cr $(EDIR)/strlwr.asm    $(ODIR)/strlwr.asm

--- a/examples/factorial.con
+++ b/examples/factorial.con
@@ -2,7 +2,7 @@ extern printf
 
 section .text
 
-function factorial(num):
+function factorial(num: dq):
 	!i rsi
 	!result rax
 	mov i, 2

--- a/examples/strchr.con
+++ b/examples/strchr.con
@@ -1,14 +1,13 @@
 extern printf
 
 section .text
-function strchr(str, chr):
+function strchr(str: dq, chr: db):
 	!ptrresult rax
-	!findchr sil
 	!end_of_str 0
 	!nullptr 0
 	mov ptrresult, nullptr
 	while byte[str] ne end_of_str:
-		if byte[str] e findchr:
+		if byte[str] e chr:
 			mov ptrresult, str
 			ret
 		inc str

--- a/examples/strlwr.con
+++ b/examples/strlwr.con
@@ -1,7 +1,7 @@
 extern printf
 
 section .text
-function strlwr(str):
+function strlwr(str: dq):
 	!A_letter 65
 	!Z_letter 90
 	!end_of_str 0

--- a/src/construct_debug.cpp
+++ b/src/construct_debug.cpp
@@ -54,7 +54,7 @@ std::string token_to_string(con_token token) {
         if (i != 0) {
           tokstring += ", ";
         }
-        tokstring += token.tok_function->arguments[i];
+        tokstring += token.tok_function->arguments[i].name + "(" + std::to_string((int(token.tok_function->arguments[i].length)+1)*8) + ")";
       }
       break;
     case CMD:

--- a/src/construct_types.h
+++ b/src/construct_types.h
@@ -5,6 +5,13 @@
 #include <vector>
 #include <stdexcept>
 
+#define assert_throw(cond, except) \
+while (false) {                    \
+  if (!(cond)) {                   \
+    throw (except);                \
+  }                                \
+}
+
 enum CON_BITWIDTH {
   BIT8,
   BIT16,
@@ -40,6 +47,13 @@ struct _con_condition {
   std::string arg2;
 };
 
+struct _con_arg {
+  std::string name;
+  CON_BITWIDTH length;
+
+  _con_arg(const std::string& _name, const CON_BITWIDTH& _length) : name(_name), length(_length) {}
+};
+
 
 struct con_section {
   std::string name;
@@ -59,7 +73,7 @@ struct con_if {
 
 struct con_function {
   std::string name;
-  std::vector<std::string> arguments;
+  std::vector<_con_arg> arguments;
 };
 
 struct con_cmd {

--- a/src/reconstruct.cpp
+++ b/src/reconstruct.cpp
@@ -117,8 +117,8 @@ void apply_functions(std::vector<con_token*>& tokens) {
     tag_tok->tok_tag->name = crntfunc->name;
     for (size_t j = 0; j < crntfunc->arguments.size(); ++j) {
       con_token* arg_tok = new con_token(MACRO);
-      arg_tok->tok_macro->value = reg_to_str(j, bitwidth);
-      arg_tok->tok_macro->macro = crntfunc->arguments[j];
+      arg_tok->tok_macro->value = reg_to_str(j, crntfunc->arguments[j].length);
+      arg_tok->tok_macro->macro = crntfunc->arguments[j].name;
 
       (*it)->tokens.insert((*it)->tokens.begin(), arg_tok);
     }
@@ -186,9 +186,8 @@ void set_indentation(std::vector<con_token*>& tokens, int parent_indentation) {
       //     ...
       //     jmp startwhile0
       //   endwhile0:
-      if (tokens.size() < 5) {
-        throw invalid_argument("while token has only "+to_string(tokens.size())+" subtokens. The least possible number is 5!");
-      }
+      assert_throw(tokens.size() >= 5, invalid_argument("while token has only "+to_string(tokens.size())+
+                                                       " subtokens. The least possible number is 5!"));
       set_indentation((*it)->tokens, parent_indentation+1);
       (*it)->tokens.front()->indentation = parent_indentation;
       (*it)->tokens.back()->indentation = parent_indentation;
@@ -200,9 +199,8 @@ void set_indentation(std::vector<con_token*>& tokens, int parent_indentation) {
       // funcname:
       //   ...
       // ret
-      if (tokens.size() < 2) {
-        throw invalid_argument("function token has only "+to_string(tokens.size())+" subtokens. The least possible number is 2!");
-      }
+      assert_throw(tokens.size() >= 2, invalid_argument("function token has only "+to_string(tokens.size())
+                                                       +" subtokens. The least possible number is 2!"));
       set_indentation((*it)->tokens, parent_indentation+1);
       (*it)->tokens.front()->indentation = parent_indentation;
       (*it)->tokens.back()->indentation = parent_indentation;
@@ -282,63 +280,46 @@ std::string reg_to_str(const uint8_t& call_num, const CON_BITWIDTH& bitwidth) {
       switch (call_num) {
         case 0:
           return "dil";
-          break;
         case 1:
           return "sil";
-          break;
         case 2:
           return "dl";
-          break;
         case 3:
           return "cl";
-          break;
         case 4:
           return "r8b";
-          break;
         case 5:
           return "r9b";
-          break;
       }
       break;
     case BIT16:
       switch (call_num) {
         case 0:
           return "di";
-          break;
         case 1:
           return "si";
-          break;
         case 2:
           return "dx";
-          break;
         case 3:
           return "cx";
-          break;
         case 4:
           return "r8w";
-          break;
         case 5:
           return "r9w";
-          break;
       }
       break;
     case BIT32:
       switch (call_num) {
         case 0:
           return "edi";
-          break;
         case 1:
           return "esi";
-          break;
         case 2:
           return "edx";
-          break;
         case 3:
           return "ecx";
-          break;
         case 4:
           return "r8d";
-          break;
         case 5:
           return "r9d";
           break;
@@ -348,27 +329,22 @@ std::string reg_to_str(const uint8_t& call_num, const CON_BITWIDTH& bitwidth) {
       switch (call_num) {
         case 0:
           return "rdi";
-          break;
         case 1:
           return "rsi";
-          break;
         case 2:
           return "rdx";
-          break;
         case 3:
           return "rcx";
-          break;
         case 4:
           return "r8";
-          break;
         case 5:
           return "r9";
-          break;
       }
       break;
+    default:
+      throw invalid_argument("Invalid call_num: "+to_string(static_cast<int>(call_num)));
   }
-  throw invalid_argument("Invalid bitwidth or call_num: bitwidth="+to_string(static_cast<int>(bitwidth))
-                         +" call_num="+to_string(static_cast<int>(call_num)));
+  throw invalid_argument("Invalid bitwidth: "+to_string(static_cast<int>(bitwidth)));
 }
 uint8_t str_to_reg(const std::string& reg_name) {
   if (reg_name=="dil" ||reg_name=="di" || reg_name=="edi" || reg_name=="rdi")


### PR DESCRIPTION
removed debug prints

added arg len to functions: db, dw, dd. dq
before:
function strchr(str, chr):
	!findchr sil
now:
function strchr(str: dq, chr: db):

add "make test" rule